### PR TITLE
Display packages in table format

### DIFF
--- a/artifacts/publish_packages_finder.py
+++ b/artifacts/publish_packages_finder.py
@@ -83,6 +83,25 @@ class PublishPackagesFinder:
     def exclude_config(self):
         return self.artifacts_config.get("exclude")
 
+    @staticmethod
+    def print_table_format(packages: list[str], headers: list[str]):
+        """
+        Print the packages in tabulate format
+
+        :param packages: list of packages
+        :param headers: headers for the table
+        :return:
+        """
+        packages_tabulate_format = [[package] for package in packages]
+
+        console.print(
+            tabulate(
+                packages_tabulate_format,
+                headers=headers,
+                tablefmt="grid"
+            )
+        )
+
     def exclude_packages_to_publish(
         self, packages: list[str], exclude_config: list[dict[str, Any]]
     ) -> list[str]:
@@ -105,7 +124,7 @@ class PublishPackagesFinder:
                 ]
         if exclude_packages:
             console.print("[blue]Following packages excluded: [/]")
-            console.print(f"[blue]{exclude_packages}[/]")
+            self.print_table_format(list(exclude_packages), ["Packages"])
             console.print("\n")
 
         return list(set(packages) - exclude_packages)
@@ -144,15 +163,8 @@ class PublishPackagesFinder:
             else:
                 console.print("[blue]Following packages will be published to PyPI.[/]")
 
-            packages_tabulate_format = [[item] for item in self.final_packages_to_publish]
+            self.print_table_format(self.final_packages_to_publish, ["Packages"])
 
-            console.print(
-                tabulate(
-                    packages_tabulate_format,
-                    headers=["Packages"],
-                    tablefmt="grid"
-                )
-            )
         except Exception as e:
             console.print(f"[red]Error: {e}[/]")
             sys.exit(1)


### PR DESCRIPTION
A sample view of the log
```
Following packages excluded: 
+-----------------------------------------------+
| Packages                                      |
+===============================================+
| apache_airflow-2.10.4.tar.gz.asc              |
+-----------------------------------------------+
| apache_airflow-2.10.4-py3-none-any.whl.sha512 |
+-----------------------------------------------+
| apache_airflow-2.10.4.tar.gz.sha512           |
+-----------------------------------------------+
| apache-airflow-2.10.4-source.tar.gz           |
+-----------------------------------------------+
| apache_airflow-2.10.4-py3-none-any.whl.asc    |
+-----------------------------------------------+
| apache-airflow-2.10.4-source.tar.gz.sha512    |
+-----------------------------------------------+
| apache-airflow-2.10.4-source.tar.gz.asc       |
+-----------------------------------------------+


To publish these packages to PyPI, set the mode=RELEASE in workflow and run
+----------------------------------------+
| Packages                               |
+========================================+
| apache_airflow-2.10.4.tar.gz           |
+----------------------------------------+
| apache_airflow-2.10.4-py3-none-any.whl |
+----------------------------------------+

```

<img width="998" alt="image" src="https://github.com/user-attachments/assets/15b93e6d-9e70-4f2e-ac26-1d23acd5099e" />
